### PR TITLE
🐛 fix(minecraft-format): 修复颜色代码解析

### DIFF
--- a/shared/utils/minecraft-format.ts
+++ b/shared/utils/minecraft-format.ts
@@ -53,6 +53,12 @@ const FORMAT_SETTERS: Partial<Record<string, (s: McSegment) => void>> = {
   },
 };
 
+/** 匹配 Bungee 的 legacy hex 颜色代码 */
+const BUNGEE_HEX_PATTERN = /^&x(&[0-9a-fA-F]){6}$/;
+
+/** Bungee 的 legacy hex 颜色代码字符串长度 */
+const HEX_LENGTH = 14;
+
 export const makeSegment = (overrides: Partial<McSegment> = {}): McSegment => ({
   bold: false,
   color: "",
@@ -76,14 +82,18 @@ const applyCode = (
   flush: () => void,
   defaultColor: string,
 ): number => {
-  // 十六进制颜色：&#RRGGBB
-  if (code === "#" && i + 7 < line.length) {
-    const hex = line.slice(i + 1, i + 8);
-    if (/^#[0-9a-fA-F]{6}$/.test(hex)) {
+  // 十六进制颜色：&x&R&R&G&G&B&B
+  if (code === "x" && i + HEX_LENGTH < line.length) {
+    const hex = line.slice(i, i + HEX_LENGTH);
+    if (BUNGEE_HEX_PATTERN.test(hex)) {
       flush();
-      st.color = hex;
+      let hexColor = "#";
+      for (let j = 3; j < HEX_LENGTH; j += 2) {
+        hexColor += hex[j];
+      }
+      st.color = hexColor;
       st.obfuscated = false;
-      return 8;
+      return HEX_LENGTH;
     }
   }
 

--- a/shared/utils/minecraft-format.ts
+++ b/shared/utils/minecraft-format.ts
@@ -159,6 +159,7 @@ export const parseMinecraftText = (
     if (li > 0) {
       flush();
       segments.push(makeSegment({ color: st.color, lineBreak: true }));
+      Object.assign(st, makeSegment({ color: defaultColor }));
     }
 
     if (line === undefined || line === "") {


### PR DESCRIPTION
修了两个小问题：

- 修复 hex 颜色格式匹配
Adventure 的 LegacyComponentSerializer 会将 Component 的 hex 颜色序列化成 Bungee 的 RGB 颜色 格式，如 &x&7&A&0&0&F&F，因此需要做相应适配以正确解析

- 换行时同时重置颜色/格式状态
防止上一行的颜色/格式代码溢出到下一行

修复前：
<img width="600" height="613" alt="eafbc9e71346642be4145f28ba50052a" src="https://github.com/user-attachments/assets/40d3b6b8-d368-4a70-93ac-aaf2a98c50e8" />
<img width="509" height="399" alt="image" src="https://github.com/user-attachments/assets/fff7b003-1291-4adc-9abb-07998536a776" />

修复后：
<img width="503" height="536" alt="a839fedb17a1abd27a3771ee05b17f04" src="https://github.com/user-attachments/assets/b1360e5f-e816-4dc7-92c0-2ffbd0857c5f" />
<img width="497" height="397" alt="image" src="https://github.com/user-attachments/assets/546add3a-f2db-4ce3-b14e-832aec7c2d58" />